### PR TITLE
add parameter to only report warnings in modified lines

### DIFF
--- a/lib/checkstyle_reports/gem_version.rb
+++ b/lib/checkstyle_reports/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CheckstyleReports
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/lib/checkstyle_reports/plugin.rb
+++ b/lib/checkstyle_reports/plugin.rb
@@ -65,8 +65,9 @@ module Danger
     #
     # @param [String] xml_file which contains checkstyle results to be reported
     # @param [Boolean] modified_files_only which is a flag to filter out non-added/non-modified files
+    # @param [Boolean] modified_lines_only only report modified lines
     # @return [void] void
-    def report(xml_file, modified_files_only: true)
+    def report(xml_file, modified_files_only: true, modified_lines_only: true)
       raise "File path must not be empty" if xml_file.empty?
       raise "File not found" unless File.exist?(xml_file)
 
@@ -80,10 +81,67 @@ module Danger
 
       @reported_files = files.map(&:relative_path)
 
-      do_comment(files) unless files.empty?
+      do_comment(files, modified_lines_only) unless files.empty?
     end
 
     private
+
+    # find the from and to positions of a chunk in a file diff
+    # adapted from https://github.com/danger/danger/blob/master/lib/danger/request_sources/github/github.rb#L371
+    #
+    # @param [Array<String>] diff_lines lines in chunk
+    # @param [String] filename the name of the file
+    # @return [Map] map of to and from position in the source file
+    def find_position_in_diff(diff_lines, filename)
+      range_header_regexp = /@@ -([0-9]+)(,([0-9]+))? \+(?<start>[0-9]+)(,(?<end>[0-9]+))? @@.*/
+      file_header_regexp = %r{^diff --git a/.*}
+
+      pattern = "+++ b/" + filename + "\n"
+      file_start = diff_lines.index(pattern)
+
+      return nil if file_start.nil?
+
+      position = -1
+      file_line = nil
+
+      diff_lines.drop(file_start).each do |line|
+        # If the line has `No newline` annotation, position need increment
+        if line.eql?("\\ No newline at end of file\n")
+          position += 1
+          next
+        end
+        # If we found the start of another file diff, we went too far
+        break if line.match file_header_regexp
+
+        match = line.match range_header_regexp
+
+        # file_line is set once we find the hunk the line is in
+        # we need to count how many lines in new file we have
+        # so we do it one by one ignoring the deleted lines
+        if !file_line.nil? && !line.start_with?("-")
+          file_line += 1
+        end
+
+        # We need to count how many diff lines are between us and
+        # the line we're looking for
+        position += 1
+
+        next unless match
+
+        range_start = match[:start].to_i
+        if match[:end]
+          range_end = match[:end].to_i + range_start
+        else
+          range_end = range_start
+        end
+
+        file_line = range_start
+
+        return { from: range_start, to: range_end } unless file_line.nil?
+      end
+
+      { from: position, to: position } unless file_line.nil?
+    end
 
     # Parse the given xml file and apply filters if needed
     #
@@ -112,8 +170,9 @@ module Danger
     # Comment errors based on the given xml file to VCS
     #
     # @param [Array<FoundFile>] files which contains checkstyle results to be reported
+    # @param [Boolean] modified_lines_only only report modified lines
     # @return [void] void
-    def do_comment(files)
+    def do_comment(files, modified_lines_only)
       base_severity = CheckstyleReports::Severity.new(min_severity)
 
       files.each do |f|
@@ -121,10 +180,17 @@ module Danger
           # check severity
           next unless base_severity <= e.severity
 
+          difffile = git.diff_for_file(f.relative_path)
+          if modified_lines_only && !difffile.nil?
+            linearray = difffile.patch.split("\n").map { |l| l + "\n" }
+            linenumbers = find_position_in_diff(linearray, difffile.path)
+            next unless e.line_number >= linenumbers[:from] && e.line_number <= linenumbers[:to]
+          end
+
           if inline_comment
             self.public_send(report_method, e.html_unescaped_message, file: f.relative_path, line: e.line_number)
           else
-            self.public_send(report_method, "#{f.relative_path} : #{e.html_unescaped_message} at #{e.line_number}")
+            self.public_send(report_method, "#{f.relative_path}: #{e.html_unescaped_message} at #{e.line_number}")
           end
         end
       end


### PR DESCRIPTION
This is my first time ever doing ruby so please bear with me :)
This creates a new parameter to only report warnings for modified lines. Not the perfect algorithm I guess but it works. 